### PR TITLE
Add "sync production-support" starter workflow

### DIFF
--- a/workflow-templates/sync-production-support-properties.json
+++ b/workflow-templates/sync-production-support-properties.json
@@ -1,0 +1,4 @@
+{
+  "name": "Sync production-support",
+  "description": "Keep a protected production-support branch in sync with the default branch, to facilitate preprod deploys (which are permitted from the default and production-support branches only)"
+}

--- a/workflow-templates/sync-production-support.yml
+++ b/workflow-templates/sync-production-support.yml
@@ -1,0 +1,23 @@
+name: Sync production-support
+
+# This workflow keeps the production-support branch in sync with the default branch, to
+# facilitate easier preprod deploys (which are permitted from the default and
+# production-support branches only).
+
+on:
+  # Auto sync on every successful status
+  status:
+  # Force sync daily at 6am AEST (cron below using UTC time)
+  schedule:
+    - cron: "0 20 * * *"
+  # Force sync on demand via manual dispatch in Actions UI
+  workflow_dispatch:
+
+jobs:
+  sync:
+    uses: cultureamp/sre-workflows/.github/workflows/sync-protected-branch.yaml@v1
+    with:
+      branch: production-support
+      from_branch: $default-branch
+    secrets:
+      token: ${{ secrets.PRODUCTION_SUPPORT_BRANCH_GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a starter workflow for keeping the production-support branch in sync with the default branch, to facilitate easier preprod deploys (which are permitted from the default and production-support branches only).

See https://github.com/cultureamp/sre-workflows/pull/1 for the details of the workflow.

This takes away some of the manual setup steps from https://cultureamp.atlassian.net/wiki/spaces/TV/pages/2741505286/Working+with+the+production-support+branch.

This is part of the "Stage separation" project (see #proj-stage-separation in Slack), which is looking to make our staging/preprod access controls equivalent to production, before later establishing the capabilities to decrease our need for that environment in the first place.

